### PR TITLE
Add GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@
 - [egghead.io](https://opencollective.com/joelhooks)
 - [Evil Martians](https://evilmartians.com/#oss)
 - [Frontend Masters](https://opencollective.com/frontendmasters)
+- [GitHub](https://fosster.herokuapp.com/) ([.](https://www.linuxfoundation.org/members/corporate)[.](https://www.freexian.com/en/services/debian-lts.html)[.](https://opencollective.com/github))
 - [Google](https://opencollective.com/google)
 - [Knight Foundation](https://opencollective.com/knightfdn)
 - [I Done This](https://opencollective.com/idonethis)


### PR DESCRIPTION
Adding GitHub to the list. We don't have a single page right now that lists everything that we sponsor (although this has motivated us to work on one) so for now there are a few different links. OK with winnowing it down to just one if that's preferable.

Disclaimer: I am a GitHub employee