### PR TITLE
Remove Google

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@
 - [Evil Martians](https://evilmartians.com/#oss)
 - [Frontend Masters](https://opencollective.com/frontendmasters)
 - [GitHub](https://fosster.herokuapp.com/) ([.](https://www.linuxfoundation.org/members/corporate)[.](https://www.freexian.com/en/services/debian-lts.html)[.](https://opencollective.com/github))
-- [Google](https://opencollective.com/google)
 - [Hubspot](https://opencollective.com/hubspot)
 - [Knight Foundation](https://opencollective.com/knightfdn)
 - [I Done This](https://opencollective.com/idonethis)


### PR DESCRIPTION
We actually didn't have substantial evidence of their support for open source *software*. The link referred to their sponsorship of an *event* ( https://sustainoss.org/ ) related to OSS, but to stay fair with the criteria that include the other companies, Google is not ticking all the boxes here.