### PR TITLE
Add Joomlatools

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@
 - [cwd.at GmbH](https://cwd.at/)
 - [synedra IT GmbH](https://opencollective.com/jfellner)
 
+# 🇧🇪 Belgium
+
+- [Joomlatools](https://www.joomlatools.com/open-source/)
+
 # 🇧🇬 Bulgaria
 
 - [HackSoft](https://hacksoft.io/blog/on-supporting-open-source-the-first-steps/)


### PR DESCRIPTION
[Joomlatools](https://www.joomlatools.com/) is a Belgian Joomla extension developer and Joomla enterprise consulting company that's passionate about Open Source!

All our software and internally created developer tools are [open source](https://www.joomlatools.com/open-source/).