### PR TITLE
Add Canopy Tax

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@
 - [AngularClass](https://opencollective.com/angularclass)
 - [Auth0](https://opencollective.com/auth0)
 - [Aviture Inc.](https://opencollective.com/contact4)
+- [Canopy Tax](https://canopytax.github.io/post/systemjs-sponsorship/)
 - [Capital One](https://opencollective.com/capitalone)
 - [Clevertech](https://opencollective.com/michellemcfarland)
 - [Comcast](http://innovationfund.comcast.com/)


### PR DESCRIPTION
Canopy Tax financially supports the third party open source project SystemJS. Read about the announcement here: https://canopytax.github.io/post/systemjs-sponsorship/

Also you will see our sponsorship listed in the project's readme.md at https://github.com/systemjs/systemjs