### PR TITLE
Add Facebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@
 - [DigitalOcean](https://opencollective.com/digitalocean)
 - [egghead.io](https://opencollective.com/joelhooks)
 - [Evil Martians](https://evilmartians.com/#oss)
+- [Facebook](https://code.facebook.com/projects/) ([.](https://www.linuxfoundation.org/members/corporate)[.](http://www.apache.org/foundation/thanks.html)[.](http://www.opencompute.org/about/membership-organizational-directory/))
 - [Frontend Masters](https://opencollective.com/frontendmasters)
 - [GitHub](https://fosster.herokuapp.com/) ([.](https://www.linuxfoundation.org/members/corporate)[.](https://www.freexian.com/en/services/debian-lts.html)[.](https://opencollective.com/github))
 - [Google](https://opensource.google.com/community/affiliations/)


### PR DESCRIPTION
Like other big companies on the list, in addition to its own open source program, Facebook is a sponsor to several foundations working on open source, including The Linux Foundation, The Apache Software Foundation, Open Compute Project, OSU Open Source Lab, and probably others I couldn’t find with a five minute Google search. I can look for more if you’d like.

It also encourages employees to contribute back to open source projects we use, and Facebook employees have contributed to projects such as Babel, Prettier, and Atom, on company time. (These are just the ones that I know off the top of my head but I can find more if needed.)

Cheers!