### PR TITLE
Add BlazeMeter

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@
 - [AngularClass](https://opencollective.com/angularclass)
 - [Auth0](https://opencollective.com/auth0)
 - [Aviture Inc.](https://opencollective.com/contact4)
+- [BlazeMeter](https://www.blazemeter.com/) ([.](http://jmeter.apache.org/changes_history.html)[.](http://www.jmeter-plugins.org/)[.](https://wiki.jenkins.io/display/JENKINS/Performance+Plugin))
 - [Canopy Tax](https://canopytax.github.io/post/systemjs-sponsorship/)
 - [Capital One](https://opencollective.com/capitalone)
 - [Clevertech](https://opencollective.com/michellemcfarland)


### PR DESCRIPTION
I received an email from BlazeMeter:

> BlazeMeter does fit into the critera, mostly by allocating time for employees to contribute but also by investing money. Here are some examples:
>
> 1. You can find BlazeMeter contributions in Apache JMeter's bug tracking lists and changelogs of past JMeter version.
http://jmeter.apache.org/changes_history.html
Just run ctrl +f on "BlazeMeter". We are also mentioned in the "special thanks" part.
>
> 2. Apache JMeter plugins is financially supported by BlazeMeter - both by manpower, hosting and also expenses for the project.
http://www.jmeter-plugins.org/
(You can see that at the top right it says "Sponsored in part by BlazeMeter)
>
> 3. BlazeMeter maintains the Apache Jmeter Jenkins performance plugin, It was an abandoned project and we maintain it now.
https://wiki.jenkins.io/display/JENKINS/Performance+Plugin
(Maintainer: Andrey Pokhilko (CA BlazeMeter) )
>
> 4. BlazeMeter maintains the Jenkins Performance Plugin:
https://wiki.jenkins.io/display/JENKINS/Performance+Plugin
(Maintainer: Andrey Pokhilko (CA BlazeMeter) )
>
> 5. BlazeMeter contributed bug fixes to the core Jenkins Pipeline plugin
https://github.com/jenkinsci/blazemeter-plugin/wiki/Using-pipeline
(Dzmitry Kashlach is a BlazeMeter employee)
dzmitry.kashlach@blazemeter.com
>
> 6. BlazeMeter contributed patches to improve distributed testing to locust.io

I would merge this since it passes all the criteria, I'm just putting it out to give a chance for review.