### PR TITLE
Add sitegeist

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
 - [Peerigon](https://opencollective.com/peerigon)
 - [reBuy](https://opencollective.com/rebuy)
 - [Sebastian Software](https://opencollective.com/sebastiansoft)
+- [sitegeist](https://sitegeist.de/) ([.](https://www.neos.io/events/neos-conference-hamburg-2017.html)[.](https://typo3.org/news/article/typo3-association-platinum-status-for-sitegeist/)[.](https://www.neos.io/contribute/donating-to-neos.html))
 
 # 🇵🇱 Poland
 


### PR DESCRIPTION
sitegeist is a German web agency based in Hamburg. Besides allowing and encouraging their employees to contribute to and/or publish their own open source projects, the company also supports the communities and development teams behind those open source products they are using on a regular basis. For the larger part these are:

* TYPO3 (https://typo3.org/)
* Neos CMS (https://www.neos.io/)

Their support for these projects includes:

* Financial support
* Organization and sponsoring of conferences, meetups and other event formats
* Contribution in community building and software development